### PR TITLE
fix(projects): send null to clear repo links on update

### DIFF
--- a/src/app/features/admin/application/components/admin-project-inline-form.spec.ts
+++ b/src/app/features/admin/application/components/admin-project-inline-form.spec.ts
@@ -1,0 +1,63 @@
+import { TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { AdminProjectInlineForm } from './admin-project-inline-form';
+import type { Project, ProjectInput } from '@features/projects/domain';
+
+function makeProject(overrides: Partial<Project> = {}): Project {
+  return {
+    id: 'p1',
+    title: 'Projet',
+    category: 'Application Web',
+    tags: ['Angular'],
+    description: 'Une description suffisante',
+    image: '',
+    featured: false,
+    order: 0,
+    repoUrl: 'https://github.com/x/repo',
+    ...overrides,
+  };
+}
+
+function mount(project?: Project) {
+  TestBed.configureTestingModule({
+    imports: [AdminProjectInlineForm],
+    schemas: [NO_ERRORS_SCHEMA],
+  });
+  const fixture = TestBed.createComponent(AdminProjectInlineForm);
+  if (project) fixture.componentRef.setInput('project', project);
+  fixture.detectChanges();
+  const cmp = fixture.componentInstance;
+  let emitted: { data: ProjectInput; file: File | null } | null = null;
+  cmp.saved.subscribe((e) => (emitted = e));
+  return { cmp, getEmitted: (): { data: ProjectInput; file: File | null } => emitted! };
+}
+
+describe('AdminProjectInlineForm — soumission', () => {
+  it('vider un lien de dépôt émet null (intention d’effacement) et non undefined', () => {
+    const { cmp, getEmitted } = mount(makeProject({ repoUrl: 'https://github.com/x/repo' }));
+
+    cmp.form.controls.repoUrl.setValue(''); // l'utilisateur efface le lien
+    cmp.submitProject();
+
+    // null est sérialisé dans le PATCH (effacement) ; undefined serait supprimé par JSON.stringify.
+    expect(getEmitted().data.repoUrl).toBeNull();
+  });
+
+  it('conserve un lien de dépôt renseigné', () => {
+    const { cmp, getEmitted } = mount(makeProject({ repoUrl: '' }));
+
+    cmp.form.controls.repoUrl.setValue('https://github.com/y/repo');
+    cmp.submitProject();
+
+    expect(getEmitted().data.repoUrl).toBe('https://github.com/y/repo');
+  });
+
+  it('un champ URL laissé vide émet null (pas de clé manquante dans le PATCH)', () => {
+    const { cmp, getEmitted } = mount(makeProject({ liveUrl: undefined, repoUrl: undefined }));
+
+    cmp.submitProject();
+
+    expect(getEmitted().data.liveUrl).toBeNull();
+    expect(getEmitted().data.repoUrl).toBeNull();
+  });
+});

--- a/src/app/features/admin/application/components/admin-project-inline-form.ts
+++ b/src/app/features/admin/application/components/admin-project-inline-form.ts
@@ -277,10 +277,12 @@ export class AdminProjectInlineForm {
       category: values.category,
       tags: [...this.selectedTags()],
       description: values.description,
-      liveUrl: values.liveUrl || undefined,
-      repoUrl: values.repoUrl || undefined,
-      repoUrlFront: values.repoUrlFront || undefined,
-      repoUrlBack: values.repoUrlBack || undefined,
+      // `null` (et non `undefined`) pour qu'un champ vidé soit envoyé dans le PATCH
+      // et efface réellement le lien côté backend (undefined serait retiré du body).
+      liveUrl: values.liveUrl || null,
+      repoUrl: values.repoUrl || null,
+      repoUrlFront: values.repoUrlFront || null,
+      repoUrlBack: values.repoUrlBack || null,
       featured: values.featured,
       order: values.order,
     };

--- a/src/app/features/projects/domain/models/project.model.ts
+++ b/src/app/features/projects/domain/models/project.model.ts
@@ -5,10 +5,13 @@ export type Project = {
   readonly tags: readonly string[];
   readonly description: string;
   readonly image: string;
-  readonly liveUrl?: string;
-  readonly repoUrl?: string;
-  readonly repoUrlFront?: string;
-  readonly repoUrlBack?: string;
+  // `null` = lien explicitement effacé (envoyé dans le PATCH pour vider le champ) ;
+  // `undefined`/absent = champ non fourni. La distinction est cruciale : JSON.stringify
+  // supprime les `undefined`, donc seul `null` transmet l'intention d'effacement au backend.
+  readonly liveUrl?: string | null;
+  readonly repoUrl?: string | null;
+  readonly repoUrlFront?: string | null;
+  readonly repoUrlBack?: string | null;
   readonly featured: boolean;
   readonly order: number;
 };


### PR DESCRIPTION
- Ensures empty URLs emit `null` to signal backend field clearing (`undefined` would be stripped by JSON.stringify).
- Verifies non-empty URLs remain intact and correctly emitted.
- Adds tests for handling `liveUrl` and `repoUrl` fields with explicit null/undefined distinction.

refactor(projects): ensure form submission sets explicit `null` for cleared link fields

- Updated `Project` model to allow `string | null` for URL fields (`liveUrl`, `repoUrl`, etc.).
- Adjusted `AdminProjectInlineForm` submission logic to serialize empty fields as `null` for backend compatibility.
