### PR TITLE
refactor(layout): remove anchor scrolling and fragment-based navigation

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -125,7 +125,6 @@ export const appConfig: ApplicationConfig = {
       withComponentInputBinding(),
       withInMemoryScrolling({
         scrollPositionRestoration: 'enabled',
-        anchorScrolling: 'enabled',
       }),
       withPreloading(SelectivePreload),
       withViewTransitions(),

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -76,6 +76,24 @@ export const routes: Routes = [
     },
   },
   {
+    path: 'contact',
+    title: 'Contact | Julien Nédellec',
+    loadComponent: () =>
+      import('./features/contact/application/contact-form').then((m) => m.ContactForm),
+    data: {
+      preload: true,
+      seo: {
+        title: 'Contact | Julien Nédellec - Développeur Full-Stack',
+        description:
+          'Une idée, un projet web Angular ou NestJS ? Contactez-moi via le formulaire — réponse rapide.',
+        keywords:
+          'Contact développeur Angular, Contact NestJS, Freelance Full-Stack, Devis projet web',
+        url: `${SITE_IDENTITY.siteUrl}/contact`,
+        type: 'website',
+      },
+    },
+  },
+  {
     path: 'login',
     title: 'Connexion | Julien Nédellec',
     loadChildren: () => import('./features/auth/auth.routes').then((m) => m.LOGIN_ROUTES),

--- a/src/app/features/contact/application/contact-form.ts
+++ b/src/app/features/contact/application/contact-form.ts
@@ -25,7 +25,7 @@ type ContactFormGroup = {
   host: { class: 'block' },
   imports: [ReactiveFormsModule, AppIcon, Button, AppIconTile],
   template: `
-    <section id="contact" class="animate-fade-up py-16 md:py-20 px-6">
+    <section class="animate-fade-up py-16 md:py-20 px-6">
       <div class="max-w-5xl mx-auto">
         <header class="text-center mb-14">
           <span

--- a/src/app/features/home/application/home.ts
+++ b/src/app/features/home/application/home.ts
@@ -2,14 +2,14 @@ import { Component, inject, ChangeDetectionStrategy, computed } from '@angular/c
 import { rxResource } from '@angular/core/rxjs-interop';
 import { HomeHeroSection } from './home-hero-section';
 import { HomeProjects } from './home-projects';
-import { ContactForm } from '@features/contact/application';
+import { RouterLink } from '@angular/router';
 import { HomeGateway } from '@features/home/domain';
 import { AppIcon } from '@shared/icons';
 import { AppIconTile } from '@shared/ui';
 
 @Component({
   selector: 'app-home',
-  imports: [HomeHeroSection, HomeProjects, ContactForm, AppIcon, AppIconTile],
+  imports: [HomeHeroSection, HomeProjects, RouterLink, AppIcon, AppIconTile],
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: { class: 'block' },
   template: `
@@ -78,18 +78,22 @@ import { AppIconTile } from '@shared/ui';
         </div>
       }
 
-      <!-- Contact Section : hydrate on viewport pour que #contact soit
-           dans le DOM des le prerender (les liens d'ancre fonctionnent
-           immediatement, avant l'hydration JS). -->
-      @defer (hydrate on viewport) {
-        <app-contact-form />
-      } @placeholder {
-        <div class="block py-16 md:py-20 px-6 h-96"></div>
-      } @error {
-        <div class="block py-16 md:py-20 px-6 text-center text-muted text-sm">
-          Impossible de charger cette section.
+      <!-- Contact CTA : la page contact est une route dédiée (/contact), pas une ancre -->
+      <section class="w-full py-16 md:py-20" aria-labelledby="contact-cta-heading">
+        <div class="page-container text-center">
+          <h2 id="contact-cta-heading" class="text-2xl md:text-3xl font-bold text-foreground mb-3">
+            Un projet, une idée&nbsp;?
+          </h2>
+          <p class="text-muted mb-8 max-w-xl mx-auto">Discutons-en ! je réponds rapidement.</p>
+          <a
+            routerLink="/contact"
+            class="inline-flex items-center gap-2 px-6 py-3 rounded-full bg-primary text-white font-medium hover:bg-primary/90 transition-colors"
+          >
+            <app-icon name="envelope" [size]="20" />
+            Me contacter
+          </a>
         </div>
-      }
+      </section>
     </main>
   `,
 })

--- a/src/app/layout/components/header/header.ts
+++ b/src/app/layout/components/header/header.ts
@@ -49,7 +49,6 @@ type ThemePreference = 'dark' | 'light';
             } @else {
               <a
                 [routerLink]="item.href"
-                [fragment]="item.fragment"
                 class="flex items-center gap-2 text-lg font-medium text-muted hover:text-primary transition-colors"
               >
                 <app-icon [name]="item.icons" [size]="20" />
@@ -118,7 +117,6 @@ type ThemePreference = 'dark' | 'light';
           } @else {
             <a
               [routerLink]="item.href"
-              [fragment]="item.fragment"
               (click)="closeMobileMenu()"
               class="flex items-center gap-3 text-lg font-medium text-muted hover:text-primary transition-colors"
             >

--- a/src/app/layout/components/header/nav-items.ts
+++ b/src/app/layout/components/header/nav-items.ts
@@ -1,12 +1,11 @@
 export type NavItem = {
   readonly label: string;
   readonly href: string;
-  readonly fragment?: string;
   readonly icons: string;
 };
 
 export const NAV_LINKS: NavItem[] = [
   { label: 'Projets', href: '/projects', icons: 'lucide-laptop' },
   { label: 'À propos', href: '/about', icons: 'lucide-user' },
-  { label: 'Contact', href: '/', fragment: 'contact', icons: 'lucide-mail' },
+  { label: 'Contact', href: '/contact', icons: 'lucide-mail' },
 ];


### PR DESCRIPTION
- Removed `[fragment]` binding from navigation links and the `anchorScrolling` feature in `app.config.ts`.
- Replaced the `#contact` anchor section with a dedicated `/contact` route for better clarity and user experience.
- Added a new `Contact` route with SEO metadata and preload configuration.
- Adjusted `home` component to include a Contact CTA linking to the dedicated route instead of rendering the `ContactForm` inline.